### PR TITLE
Fixes #2 - add support for caching async functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ assert func(4) is func(4)
 If instead we used `@cached(scope='thread')`, repeated calls with the same arguments within the same thread would
 return the same object, but not in different threads.
 
+> ℹ️ **Concurrent programming:**  
+> Async functions and methods can be cached using the same syntax.
+
 > ⚠️ **Caching methods:**  
 > The decorator does not handle methods any differently than regular functions, i.e. `self` is
 > treated like any other argument. This means that, for a `@cached` method, if any member of `self` has changed,

--- a/epic/caching/_async.py
+++ b/epic/caching/_async.py
@@ -1,0 +1,39 @@
+import asyncio
+import inspect
+from typing import Awaitable, TypeVar, Generic
+
+T = TypeVar('T')
+
+
+class CoroutineFactory(Generic[T]):
+    """A factory for 'secondary' coroutines that, when awaited, each return the result of a 'primary' coroutine.
+    This enables caching of async functions, which don't return values but instead coroutines which can only be
+    awaited once.
+    The primary coroutine is lazily started only when one of the secondary coroutines is started.
+    """
+    def __init__(self, coroutine: Awaitable[T]):
+        self.primary = coroutine
+        self.shared_future = asyncio.Future()
+        self.primary_started = False
+        self.start_lock = asyncio.Lock()
+
+    async def _run_primary(self):
+        try:
+            result = await self.primary
+            if not self.shared_future.done():
+                self.shared_future.set_result(result)
+        except Exception as e:
+            if not self.shared_future.done():
+                self.shared_future.set_exception(e)
+
+    async def make_secondary(self) -> Awaitable[T]:
+        if not self.primary_started:
+            async with self.start_lock:
+                if not self.primary_started:
+                    self.primary_started = True
+                    asyncio.create_task(self._run_primary())
+        return await self.shared_future
+
+
+def requires_async_caching(func):
+    return inspect.iscoroutinefunction(func)

--- a/epic/caching/_async.py
+++ b/epic/caching/_async.py
@@ -1,38 +1,40 @@
 import asyncio
 import inspect
-from typing import Awaitable, TypeVar, Generic
+from typing import TypeVar, Generic
+from collections.abc import Awaitable
 
 T = TypeVar('T')
 
 
-class CoroutineFactory(Generic[T]):
-    """A factory for 'secondary' coroutines that, when awaited, each return the result of a 'primary' coroutine.
-    This enables caching of async functions, which don't return values but instead coroutines which can only be
+class CachedAwaitableRunner(Generic[T]):
+    """Given an Awaitable, allow await-ing it multiple times by running it once and caching the result.
+    The original coroutine is lazily started only upon the first all to `cached_run`.
+
+    This class enables caching of async functions, which don't return values but instead coroutines which can only be
     awaited once.
-    The primary coroutine is lazily started only when one of the secondary coroutines is started.
     """
-    def __init__(self, coroutine: Awaitable[T]):
-        self.primary = coroutine
-        self.shared_future = asyncio.Future()
-        self.primary_started = False
+    def __init__(self, awaitable: Awaitable[T]):
+        self.awaitable = awaitable
+        self.task = None
+        self.shared_future = None
         self.start_lock = asyncio.Lock()
 
-    async def _run_primary(self):
+    async def cached_run(self) -> T:
+        if self.task is None:
+            async with self.start_lock:
+                if self.task is None:
+                    self.shared_future = asyncio.get_running_loop().create_future()
+                    self.task = asyncio.create_task(self._run())
+        return await self.shared_future
+
+    async def _run(self):
         try:
-            result = await self.primary
+            result = await self.awaitable
             if not self.shared_future.done():
                 self.shared_future.set_result(result)
         except Exception as e:
             if not self.shared_future.done():
                 self.shared_future.set_exception(e)
-
-    async def make_secondary(self) -> Awaitable[T]:
-        if not self.primary_started:
-            async with self.start_lock:
-                if not self.primary_started:
-                    self.primary_started = True
-                    asyncio.create_task(self._run_primary())
-        return await self.shared_future
 
 
 def requires_async_caching(func):

--- a/epic/caching/cached.py
+++ b/epic/caching/cached.py
@@ -8,7 +8,7 @@ from typing import TypeVar, ParamSpec, Concatenate, Literal, Any
 from epic.common.general import hash_content
 
 from ._cache import Cache, ThreadCache, ProcessCache
-from ._async import CoroutineFactory, requires_async_caching
+from ._async import CachedAwaitableRunner, requires_async_caching
 
 
 T = TypeVar('T')
@@ -38,20 +38,18 @@ def _cached_call_impl(
         bound_args = inspect.signature(init_method).bind(None, *args, **kwargs)
     key = hash_content(bound_args.arguments)
     is_async = requires_async_caching(callfunc)
-    if is_async:
-        cache: Cache[int, CoroutineFactory[T]] = cache_class(name)
-    else:
-        cache: Cache[int, T] = cache_class(name)
+    cache: Cache[int, CachedAwaitableRunner if is_async else T] = cache_class(name)
+    print(f"--- cache: {key=} | {bound_args.arguments=}")
     if key not in cache:
         with cache.lock(key):
             if key not in cache:
                 result = callfunc(*args, **kwargs)
                 if is_async:
-                    result = CoroutineFactory(result)
+                    result = CachedAwaitableRunner(result)
                 cache[key] = result
     result = cache[key]
     if is_async:
-        result = result.make_secondary()
+        result = result.cached_run()
     return result
 
 

--- a/epic/caching/cached.py
+++ b/epic/caching/cached.py
@@ -38,8 +38,7 @@ def _cached_call_impl(
         bound_args = inspect.signature(init_method).bind(None, *args, **kwargs)
     key = hash_content(bound_args.arguments)
     is_async = requires_async_caching(callfunc)
-    cache: Cache[int, CachedAwaitableRunner if is_async else T] = cache_class(name)
-    print(f"--- cache: {key=} | {bound_args.arguments=}")
+    cache: Cache = cache_class(name)
     if key not in cache:
         with cache.lock(key):
             if key not in cache:

--- a/epic/caching/cached.py
+++ b/epic/caching/cached.py
@@ -8,6 +8,7 @@ from typing import TypeVar, ParamSpec, Concatenate, Literal, Any
 from epic.common.general import hash_content
 
 from ._cache import Cache, ThreadCache, ProcessCache
+from ._async import CoroutineFactory, requires_async_caching
 
 
 T = TypeVar('T')
@@ -36,12 +37,22 @@ def _cached_call_impl(
         # Add an extra argument for 'self'
         bound_args = inspect.signature(init_method).bind(None, *args, **kwargs)
     key = hash_content(bound_args.arguments)
-    cache: Cache[int, T] = cache_class(name)
+    is_async = requires_async_caching(callfunc)
+    if is_async:
+        cache: Cache[int, CoroutineFactory[T]] = cache_class(name)
+    else:
+        cache: Cache[int, T] = cache_class(name)
     if key not in cache:
         with cache.lock(key):
             if key not in cache:
-                cache[key] = callfunc(*args, **kwargs)
-    return cache[key]
+                result = callfunc(*args, **kwargs)
+                if is_async:
+                    result = CoroutineFactory(result)
+                cache[key] = result
+    result = cache[key]
+    if is_async:
+        result = result.make_secondary()
+    return result
 
 
 def cached_call(callable_obj: Callable[P, T], *args: P.args, scope: Scope = 'process',

--- a/poetry.lock
+++ b/poetry.lock
@@ -186,6 +186,24 @@ tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.0.0"
+description = "Pytest support for asyncio"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pytest_asyncio-1.0.0-py3-none-any.whl", hash = "sha256:4f024da9f1ef945e680dc68610b52550e36590a67fd31bb3b4943979a1f90ef3"},
+    {file = "pytest_asyncio-1.0.0.tar.gz", hash = "sha256:d15463d13f4456e1ead2594520216b225a16f781e144f8fdf6c5bb4667c48b3f"},
+]
+
+[package.dependencies]
+pytest = ">=8.2,<9"
+
+[package.extras]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1)"]
+testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
+
+[[package]]
 name = "pytest-cov"
 version = "6.0.0"
 description = "Pytest plugin for measuring coverage."
@@ -261,4 +279,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "5957bd32ff63005743bb91991f44eadccfa2b174f3743fa8799eb2d8a94cf313"
+content-hash = "889bbba1cc52c06b9367791e04dc76de9405b3ad7e857356387524b6cbb30907"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ epic-common = "*"
 pytest = "*"
 pytest-cov = "*"
 pytest-timeout = "*"
-pytest-asyncio = "*"
+pytest-asyncio = "^1.0.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,12 @@ epic-common = "*"
 pytest = "*"
 pytest-cov = "*"
 pytest-timeout = "*"
+pytest-asyncio = "*"
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,0 +1,46 @@
+import pytest
+import random
+import asyncio
+from epic.caching._async import CoroutineFactory
+
+class MyException(Exception):
+    """Specific exception to be detected by test"""
+
+
+class TestCoroutineFactory:
+    started_once = False
+
+    @classmethod
+    async def async_func(cls, *, should_err=False, mark_started=False):
+        if mark_started:
+            cls.started_once = True
+        if should_err:
+            raise MyException("error raised from async function")
+        return random.random()
+
+    async def test_basic(self):
+        value1 = await self.async_func()
+        cf = CoroutineFactory(self.async_func())
+        value2 = await cf.make_secondary()
+        value3 = await cf.make_secondary()
+        assert value1 != value2
+        assert value2 == value3
+
+    async def test_lazy_start(self):
+        cf = CoroutineFactory(self.async_func(mark_started=True))
+        assert not self.started_once
+        secondaries = [cf.make_secondary() for _ in range(100)]
+        random.shuffle(secondaries)
+        await asyncio.sleep(0.2)
+        assert not self.started_once
+        values = await asyncio.gather(*secondaries)
+        assert len(set(values)) == 1
+
+    async def test_exceptions(self):
+        cf = CoroutineFactory(self.async_func(should_err=True))
+        for i in range(5):
+            secondaries = [cf.make_secondary() for _ in range(5 - i)]
+            random.shuffle(secondaries)
+            for secondary in secondaries:
+                with pytest.raises(MyException):
+                    await secondary

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,13 +1,18 @@
-import pytest
+import time
 import random
 import asyncio
-from epic.caching._async import CoroutineFactory
 
-class MyException(Exception):
-    """Specific exception to be detected by test"""
+import pytest
+
+from epic.caching import cached
+from epic.caching._async import CachedAwaitableRunner
 
 
-class TestCoroutineFactory:
+class SpecificException(Exception):
+    """Specific exception subtype to be detected by test"""
+
+
+class TestCachedAwaitableRunner:
     started_once = False
 
     @classmethod
@@ -15,21 +20,21 @@ class TestCoroutineFactory:
         if mark_started:
             cls.started_once = True
         if should_err:
-            raise MyException("error raised from async function")
+            raise SpecificException("error raised from async function")
         return random.random()
 
     async def test_basic(self):
         value1 = await self.async_func()
-        cf = CoroutineFactory(self.async_func())
-        value2 = await cf.make_secondary()
-        value3 = await cf.make_secondary()
+        cf = CachedAwaitableRunner(self.async_func())
+        value2 = await cf.cached_run()
+        value3 = await cf.cached_run()
         assert value1 != value2
         assert value2 == value3
 
     async def test_lazy_start(self):
-        cf = CoroutineFactory(self.async_func(mark_started=True))
+        cf = CachedAwaitableRunner(self.async_func(mark_started=True))
         assert not self.started_once
-        secondaries = [cf.make_secondary() for _ in range(100)]
+        secondaries = [cf.cached_run() for _ in range(100)]
         random.shuffle(secondaries)
         await asyncio.sleep(0.2)
         assert not self.started_once
@@ -37,10 +42,70 @@ class TestCoroutineFactory:
         assert len(set(values)) == 1
 
     async def test_exceptions(self):
-        cf = CoroutineFactory(self.async_func(should_err=True))
+        cf = CachedAwaitableRunner(self.async_func(should_err=True))
         for i in range(5):
-            secondaries = [cf.make_secondary() for _ in range(5 - i)]
+            secondaries = [cf.cached_run() for _ in range(5 - i)]
             random.shuffle(secondaries)
             for secondary in secondaries:
-                with pytest.raises(MyException):
+                with pytest.raises(SpecificException):
                     await secondary
+
+
+class TestCachingAsyncFunctions:
+    async def test_simple(self):
+        started = False
+
+        @cached
+        async def func():
+            nonlocal started
+            started = True
+            return random.random()
+
+        assert not started
+        f1 = func()
+        assert not started
+        a = await f1
+        assert started
+        b = await func()
+        assert a == b
+
+    async def test_async_method(self):
+        call_count = 0
+
+        class ClassWithAsyncMethod:
+            @cached
+            async def random_value(self):
+                nonlocal call_count
+                call_count += 1
+                await asyncio.sleep(0.1)
+                return random.random()
+
+        instance0 = ClassWithAsyncMethod()
+        value0 = await instance0.random_value()
+        assert value0 == await instance0.random_value()
+
+        call_count = 0
+        instance1 = ClassWithAsyncMethod()
+        instance2 = ClassWithAsyncMethod()
+        assert call_count == 0
+        future1 = instance1.random_value()
+        future2 = instance2.random_value()
+        assert call_count == 0
+        value1 = await future1
+        assert call_count == 1
+        assert value1 == await instance1.random_value()
+        assert call_count == 1
+        value2 = await future2
+        assert call_count == 2
+        assert value2 == await instance2.random_value()
+        assert call_count == 2
+
+    async def test_timing(self):
+        @cached
+        async def async_sleep(interval):
+            await asyncio.sleep(interval)
+
+        t0 = time.time()
+        await async_sleep(0.1)
+        await async_sleep(0.1)
+        assert time.time() - t0 < 0.15

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -224,19 +224,3 @@ def test_lazy_property():
     value = obj.prop
     assert value is not None
     assert obj.prop is value
-
-
-async def test_async():
-    started = False
-    @cached
-    async def func():
-        nonlocal started
-        started = True
-        return random.random()
-    assert not started
-    f1 = func()
-    assert not started
-    a = await f1
-    assert started
-    b = await func()
-    assert a == b

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -224,3 +224,19 @@ def test_lazy_property():
     value = obj.prop
     assert value is not None
     assert obj.prop is value
+
+
+async def test_async():
+    started = False
+    @cached
+    async def func():
+        nonlocal started
+        started = True
+        return random.random()
+    assert not started
+    f1 = func()
+    assert not started
+    a = await f1
+    assert started
+    b = await func()
+    assert a == b


### PR DESCRIPTION
When caching async functions (that return coroutines), a CoroutineFactory is created and cached to return new derivative coroutines whenever the cached function is invoked. The original coroutine is started whenever any derivative coroutine is stared.

What I'm still missing:
- I'm not sure this covers all usage patterns supported by the library that could potentially have async use cases
- I have not added any documentation for async aspects
- We may want to add additional tests, perhaps expanding `TestCached` matrix to also cover the `sync/async` dimension

Preliminary review for the solution implementation would be welcome at this stage.